### PR TITLE
Make nut-2.8.0 work with plugin

### DIFF
--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -237,14 +237,28 @@ else
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz
 
-    rm -rf /etc/ups
-    ln -s /etc/nut /etc/ups
-    mkdir /var/run/nut
-    ln -s /var/run/upsmon.pid /var/run/nut/upsmon.pid
-
     # Stop service
     echo "stopping services..."
     /etc/rc.d/rc.nut stop 2>/dev/null
+
+    # nut-2.7.4 and nut plugin expects:
+    #   Config: /etc/nut
+    #   Pid   : /var/run/nut/upsmon.pid
+
+    # nut-2.8.0 expects
+    #   Config: /etc/ups
+    #   Pid   : /var/run/upsmon.pid
+
+    if [ ! -d /etc/nut ]; then
+        # Link nut-2.8.0 config to nut-2.7.4 config
+        mkdir /etc/nut
+        cp /etc/ups/* /etc/nut
+        rm -rf /etc/ups
+        ln -s /etc/nut /etc/ups
+        # Link nut-2.7.4 pid to nut-2.8.0 pid
+        mkdir /var/run/nut
+        ln -s /var/run/upsmon.pid /var/run/nut/upsmon.pid
+    fi
 
     # start network ups tools
     echo "checking network ups tools configuration..."
@@ -290,6 +304,11 @@ removepkg &plgPATH;/*.txz
 rm -rf &emhttp;
 rm -f &plgPATH;/*.txz \
     &plgPATH;/*.md5
+
+# Remove links for nut-2.8.0 vs nut-2.7.4
+rm -rf /etc/nut
+rm /etc/ups
+rm -rf /var/run/nut
 
 echo ""
 echo "-----------------------------------------------------------"

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -234,13 +234,6 @@ if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
     rm &plgPATH;/&plgNAME;.md5
     exit 1
 else
-    # upgrade plugin package
-    upgradepkg --install-new &plgPATH;/&plgNAME;.txz
-
-    # Stop service
-    echo "stopping services..."
-    /etc/rc.d/rc.nut stop 2>/dev/null
-
     # nut-2.7.4 and nut plugin expects:
     #   Config: /etc/nut
     #   Pid   : /var/run/nut/upsmon.pid
@@ -259,6 +252,13 @@ else
         mkdir /var/run/nut
         ln -s /var/run/upsmon.pid /var/run/nut/upsmon.pid
     fi
+
+    # upgrade plugin package
+    upgradepkg --install-new &plgPATH;/&plgNAME;.txz
+
+    # Stop service
+    echo "stopping services..."
+    /etc/rc.d/rc.nut stop 2>/dev/null
 
     # start network ups tools
     echo "checking network ups tools configuration..."


### PR DESCRIPTION
I don't use github very much so please forgive me if I'm not doing the pull request correctly.  When the nut-2.8.0 package is installed, it does not create the /etc/nut directory and the /etc/ups link points to nothing.  So these changes check if /etc/nut exists, and if it doesn't, it creates /etc/nut, copies everything from /etc/ups to /etc/nut, links /etc/ups to /etc/nut, and links /var/run/nut/upsmon.pid to /var/run/upsmon.pid.  It also deletes the extra stuff when the plugin is uninstalled.

Also, the plugin tries to install both nut-2.8.0 (succeeds) and nut-2.7.4 (skips, newer version already installed), and both net-snmp-5.9.3 (succeeds) and net-snmp-5.7.3 (skips, newer version already installed). I'm not sure how to fix that.