### PR TITLE
reduce console spam + save diagnostics function

### DIFF
--- a/source/nut/etc/rc.d/rc.nut
+++ b/source/nut/etc/rc.d/rc.nut
@@ -205,7 +205,7 @@ write_config() {
         mkdir $PLGPATH/ups
     fi
 	
-    cp -f /etc/nut/* $PLGPATH/ups
+    cp -f /etc/nut/* $PLGPATH/ups >/dev/null 2>&1
  
     # update permissions
     if [ -d /etc/nut ]; then

--- a/source/nut/install/doinst.sh
+++ b/source/nut/install/doinst.sh
@@ -17,7 +17,7 @@ chmod +0755 $DOCROOT/scripts/* \
         /usr/sbin/nut-notify
 
 # copy the default
-cp -nr $DOCROOT/default.cfg $BOOT/nut.cfg
+cp -nr $DOCROOT/default.cfg $BOOT/nut.cfg >/dev/null 2>&1
 
 # remove nut symlink
 if [ -L /etc/nut ]; then
@@ -31,10 +31,10 @@ if [ ! -d $BOOT/ups ]; then
 fi
 
 # copy default conf files to flash drive, if no backups exist there
-cp -nr $DOCROOT/nut/* $BOOT/ups
+cp -nr $DOCROOT/nut/* $BOOT/ups >/dev/null 2>&1
 
 # copy conf files from flash drive to local system, for our services to use
-cp -f $BOOT/ups/* /etc/nut
+cp -f $BOOT/ups/* /etc/nut >/dev/null 2>&1
 
 # update permissions
 if [ -d /etc/nut ]; then

--- a/source/nut/usr/local/emhttp/plugins/nut/NUTdetails.page
+++ b/source/nut/usr/local/emhttp/plugins/nut/NUTdetails.page
@@ -32,6 +32,8 @@ table.tablesorter tbody tr:nth-child(even) {
 <tbody id="nut_status"><tr><td colspan="4" style="text-align:center"><i class="fa fa-spinner fa-spin icon"></i><em>Please wait, retrieving UPS information...</em></td></tr></tbody>
 </table>
 
+<div style="font-size:x-small;font-weight:bold;"><a href="/plugins/nut/include/nut_status.php?diagsave=true&all=true">Save Diagnostics</a></div>
+
 <script>
 function getNUTstatus() {
   $.get('/plugins/nut/include/nut_status.php',{all:'true'},function(data) {

--- a/source/nut/usr/local/emhttp/plugins/nut/include/nut_status.php
+++ b/source/nut/usr/local/emhttp/plugins/nut/include/nut_status.php
@@ -29,6 +29,18 @@ $result = [];
 
 if (file_exists('/var/run/nut/upsmon.pid')) {
   exec("/usr/bin/upsc ".escapeshellarg($nut_name)."@$nut_ip 2>/dev/null", $rows);
+
+  if ($_GET['diagsave'] == "true") {
+
+  $diagstring = implode("\n",$rows);
+  header('Content-Disposition: attachment; filename="nut-diagnostics.dev"');
+  header('Content-Type: text/plain');
+  header('Content-Length: ' . strlen($diagstring));
+  header('Connection: close');
+  die($diagstring);
+
+  }
+
   for ($i=0; $i<count($rows); $i++) {
     $row = array_map('trim', explode(':', $rows[$i], 2));
     $key = $row[0];


### PR DESCRIPTION
fix: reduce console spam (as requested in [#3 ](https://github.com/SimonFair/NUT-unRAID/pull/3#issuecomment-1649094177))
new: add button for users to be able to save their UPS details into a diagnostics file (to give the devs when problems arise)