### PR TITLE
2023.07.26

### DIFF
--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -36,6 +36,12 @@
 - add: implement battery replacement notification in settings
 
         Thanks to forum member Rysz for the PR.
+###2023.06.03
+- Add Small footer style thanks ich777 for the PR.
+###2023.02.14
+-6.12 Dashboard support
+-PHP8 fixes
+-Refresh option.
 ###2022.03.20
 -fix for filetree top level
 -update nut footer
@@ -259,10 +265,6 @@ else
         /etc/rc.d/rc.nut stop 2>/dev/null
     fi
 
-    # start install always with fresh folders
-    rm -rf /etc/nut
-    rm -rf /etc/ups
-
     # nut-2.7.4 and nut plugin expects:
     #   Config: /etc/nut
     #   Pid   : /var/run/nut/upsmon.pid
@@ -344,6 +346,7 @@ rm -rf /var/run/nut
 # in case of re-installation of package on live system
 rm -rf /etc/nut
 rm -rf /etc/ups
+rm -rf /var/run/nut
 
 echo ""
 echo "-----------------------------------------------------------"

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -253,6 +253,10 @@ if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
     rm &plgPATH;/&plgNAME;.md5
     exit 1
 else
+    # if upgrading on live system, stop the services here
+    # to release any remaining file locks before patching
+    [ -x /etc/rc.d/rc.nut ] && /etc/rc.d/rc.nut stop 2>/dev/null
+
     # nut-2.7.4 and nut plugin expects:
     #   Config: /etc/nut
     #   Pid   : /var/run/nut/upsmon.pid
@@ -264,17 +268,13 @@ else
     if [ ! -d /etc/nut ]; then
         # Link nut-2.8.0 config to nut-2.7.4 config
         mkdir /etc/nut
-        cp /etc/ups/* /etc/nut
+        cp -f /etc/ups/* /etc/nut
         rm -rf /etc/ups
         ln -s /etc/nut /etc/ups
         # Link nut-2.7.4 pid to nut-2.8.0 pid
         mkdir /var/run/nut
         ln -s /var/run/upsmon.pid /var/run/nut/upsmon.pid
     fi
-
-    # if upgrading on live system, stop the services here
-    # to release any remaining file locks before patching
-    [ -x /etc/rc.d/rc.nut ] && /etc/rc.d/rc.nut stop 2>/dev/null
 
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz
@@ -331,7 +331,7 @@ rm -f &plgPATH;/*.txz \
 
 # Remove links for nut-2.8.0 vs nut-2.7.4
 rm -rf /etc/nut
-rm /etc/ups
+rm -f /etc/ups
 rm -rf /var/run/nut
 
 echo ""

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -334,7 +334,7 @@ rm -rf /etc/nut
 rm -f /etc/ups
 rm -rf /var/run/nut
 
-# clean up once more in case of reinstall on live system
+# clean up once more in case of reinstall of other nut package on live system
 rm -rf /etc/nut
 rm -rf /etc/ups
 

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -270,10 +270,10 @@ else
         mkdir /etc/nut
         cp -f /etc/ups/* /etc/nut
         rm -rf /etc/ups
-        ln -s /etc/nut /etc/ups
+        ln -sf /etc/nut /etc/ups
         # Link nut-2.7.4 pid to nut-2.8.0 pid
         mkdir /var/run/nut
-        ln -s /var/run/upsmon.pid /var/run/nut/upsmon.pid
+        ln -sf /var/run/upsmon.pid /var/run/nut/upsmon.pid
     fi
 
     # upgrade plugin package

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -244,11 +244,6 @@ if [[ ${version:0:3} == 6.0 ]]; then
     exit 1
 fi
 
-# start install always with fresh folders
-# in case of unclean old installation remnants
-rm -rf /etc/nut
-rm -rf /etc/ups
-
 # Verify and install plugin package
 sum1=$(/usr/bin/md5sum &plgPATH;/&plgNAME;.txz)
 sum2=$(/usr/bin/cat &plgPATH;/&plgNAME;.md5)
@@ -263,6 +258,10 @@ else
     if [ -x /etc/rc.d/rc.nut ]; then
         /etc/rc.d/rc.nut stop 2>/dev/null
     fi
+
+    # start install always with fresh folders
+    rm -rf /etc/nut
+    rm -rf /etc/ups
 
     # nut-2.7.4 and nut plugin expects:
     #   Config: /etc/nut

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -244,6 +244,11 @@ if [[ ${version:0:3} == 6.0 ]]; then
     exit 1
 fi
 
+# start install always with fresh folders
+# in case of unclean old installation remnants
+rm -rf /etc/nut
+rm -rf /etc/ups
+
 # Verify and install plugin package
 sum1=$(/usr/bin/md5sum &plgPATH;/&plgNAME;.txz)
 sum2=$(/usr/bin/cat &plgPATH;/&plgNAME;.md5)
@@ -334,7 +339,8 @@ rm -rf /etc/nut
 rm -f /etc/ups
 rm -rf /var/run/nut
 
-# clean up once more in case of reinstall of other nut package on live system
+# clean up folders after the removed installation
+# in case of re-installation of package on live system
 rm -rf /etc/nut
 rm -rf /etc/ups
 

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -334,6 +334,10 @@ rm -rf /etc/nut
 rm -f /etc/ups
 rm -rf /var/run/nut
 
+# clean up once more in case of reinstall on live system
+rm -rf /etc/nut
+rm -rf /etc/ups
+
 echo ""
 echo "-----------------------------------------------------------"
 echo " &name; has been removed."

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -260,7 +260,9 @@ if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
 else
     # if upgrading on live system, stop the services here
     # to release any remaining file locks before patching
-    [ -x /etc/rc.d/rc.nut ] && /etc/rc.d/rc.nut stop 2>/dev/null
+    if [ -x /etc/rc.d/rc.nut ]; then
+        /etc/rc.d/rc.nut stop 2>/dev/null
+    fi
 
     # nut-2.7.4 and nut plugin expects:
     #   Config: /etc/nut

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -272,6 +272,10 @@ else
         ln -s /var/run/upsmon.pid /var/run/nut/upsmon.pid
     fi
 
+    # if upgrading on live system, stop the services here
+    # to release any remaining file locks before patching
+    [ -x /etc/rc.d/rc.nut ] && /etc/rc.d/rc.nut stop 2>/dev/null
+
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz
 

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -249,8 +249,8 @@ sum1=$(/usr/bin/md5sum &plgPATH;/&plgNAME;.txz)
 sum2=$(/usr/bin/cat &plgPATH;/&plgNAME;.md5)
 if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
     echo "Wrong 'plugin' package md5 hash."
-    rm &plgPATH;/&plgNAME;.txz
-    rm &plgPATH;/&plgNAME;.md5
+    rm -f &plgPATH;/&plgNAME;.txz
+    rm -f &plgPATH;/&plgNAME;.md5
     exit 1
 else
     # if upgrading on live system, stop the services here

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -254,7 +254,9 @@ if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
 else
     # if upgrading on live system, stop the services here
     # to release any remaining file locks before patching
-    [ -x /etc/rc.d/rc.nut ] && /etc/rc.d/rc.nut stop 2>/dev/null
+    if [ -x /etc/rc.d/rc.nut ]; then
+        /etc/rc.d/rc.nut stop 2>/dev/null
+    fi
 
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -304,6 +304,10 @@ rm -rf &plgPATH;/ups
 rm -f &plgPATH;/*.txz \
     &plgPATH;/*.md5
 
+# clean up once more in case of reinstall on live system
+rm -rf /etc/nut
+rm -rf /etc/ups
+
 echo ""
 echo "-----------------------------------------------------------"
 echo " &name; has been removed."

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -238,6 +238,11 @@ if [[ ${version:0:3} == 6.0 ]]; then
     exit 1
 fi
 
+# start install always with fresh folders
+# in case of unclean old installation remnants
+rm -rf /etc/nut
+rm -rf /etc/ups
+
 # Verify and install plugin package
 sum1=$(/usr/bin/md5sum &plgPATH;/&plgNAME;.txz)
 sum2=$(/usr/bin/cat &plgPATH;/&plgNAME;.md5)
@@ -304,7 +309,8 @@ rm -rf &plgPATH;/ups
 rm -f &plgPATH;/*.txz \
     &plgPATH;/*.md5
 
-# clean up once more in case of reinstall of other nut package on live system
+# clean up folders after the removed installation
+# in case of re-installation of package on live system
 rm -rf /etc/nut
 rm -rf /etc/ups
 rm -rf /var/run/nut

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -304,9 +304,10 @@ rm -rf &plgPATH;/ups
 rm -f &plgPATH;/*.txz \
     &plgPATH;/*.md5
 
-# clean up once more in case of reinstall on live system
+# clean up once more in case of reinstall of other nut package on live system
 rm -rf /etc/nut
 rm -rf /etc/ups
+rm -rf /var/run/nut
 
 echo ""
 echo "-----------------------------------------------------------"

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -247,6 +247,10 @@ if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
     rm &plgPATH;/&plgNAME;.md5
     exit 1
 else
+    # if upgrading on live system, stop the services here
+    # to release any remaining file locks before patching
+    [ -x /etc/rc.d/rc.nut ] && /etc/rc.d/rc.nut stop 2>/dev/null
+
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz
 

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -243,8 +243,8 @@ sum1=$(/usr/bin/md5sum &plgPATH;/&plgNAME;.txz)
 sum2=$(/usr/bin/cat &plgPATH;/&plgNAME;.md5)
 if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
     echo "Wrong 'plugin' package md5 hash."
-    rm &plgPATH;/&plgNAME;.txz
-    rm &plgPATH;/&plgNAME;.md5
+    rm -f &plgPATH;/&plgNAME;.txz
+    rm -f &plgPATH;/&plgNAME;.md5
     exit 1
 else
     # if upgrading on live system, stop the services here

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -256,7 +256,6 @@ else
     # start install always with fresh folders
     rm -rf /etc/nut
     rm -rf /etc/ups
-    mkdir /etc/nut
 
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -253,10 +253,6 @@ else
         /etc/rc.d/rc.nut stop 2>/dev/null
     fi
 
-    # start install always with fresh folders
-    rm -rf /etc/nut
-    rm -rf /etc/ups
-
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz
 

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -238,11 +238,6 @@ if [[ ${version:0:3} == 6.0 ]]; then
     exit 1
 fi
 
-# start install always with fresh folders
-# in case of unclean old installation remnants
-rm -rf /etc/nut
-rm -rf /etc/ups
-
 # Verify and install plugin package
 sum1=$(/usr/bin/md5sum &plgPATH;/&plgNAME;.txz)
 sum2=$(/usr/bin/cat &plgPATH;/&plgNAME;.md5)
@@ -257,6 +252,11 @@ else
     if [ -x /etc/rc.d/rc.nut ]; then
         /etc/rc.d/rc.nut stop 2>/dev/null
     fi
+
+    # start install always with fresh folders
+    rm -rf /etc/nut
+    rm -rf /etc/ups
+    mkdir /etc/nut
 
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz

--- a/source/nut/etc/rc.d/rc.nut
+++ b/source/nut/etc/rc.d/rc.nut
@@ -205,7 +205,7 @@ write_config() {
         mkdir $PLGPATH/ups
     fi
 	
-    cp -f /etc/nut/* $PLGPATH/ups
+    cp -f /etc/nut/* $PLGPATH/ups >/dev/null 2>&1
  
     # update permissions
     if [ -d /etc/nut ]; then

--- a/source/nut/etc/rc.d/rc.nut
+++ b/source/nut/etc/rc.d/rc.nut
@@ -214,6 +214,8 @@ write_config() {
         chmod 640 /etc/nut/*
         chown root:nut /var/run/nut
         chmod 0770 /var/run/nut
+        chown root:nut /var/state/ups
+        chmod 0770 /var/state/ups
         #chown -R 218:218 /etc/nut
         #chmod -R 0644 /etc/nut
     fi

--- a/source/nut/install/doinst.sh
+++ b/source/nut/install/doinst.sh
@@ -25,6 +25,11 @@ if [ -L /etc/nut ]; then
     mkdir /etc/nut
 fi
 
+# create nut directory
+if [ ! -d /etc/nut ]; then
+    mkdir /etc/nut
+fi
+
 # prepare conf backup directory on flash drive, if it does not already exist
 if [ ! -d $BOOT/ups ]; then
     mkdir $BOOT/ups

--- a/source/nut/install/doinst.sh
+++ b/source/nut/install/doinst.sh
@@ -17,7 +17,7 @@ chmod +0755 $DOCROOT/scripts/* \
         /usr/sbin/nut-notify
 
 # copy the default
-cp -nr $DOCROOT/default.cfg $BOOT/nut.cfg
+cp -nr $DOCROOT/default.cfg $BOOT/nut.cfg >/dev/null 2>&1
 
 # remove nut symlink
 if [ -L /etc/nut ]; then
@@ -31,10 +31,10 @@ if [ ! -d $BOOT/ups ]; then
 fi
 
 # copy default conf files to flash drive, if no backups exist there
-cp -nr $DOCROOT/nut/* $BOOT/ups
+cp -nr $DOCROOT/nut/* $BOOT/ups >/dev/null 2>&1
 
 # copy conf files from flash drive to local system, for our services to use
-cp -f $BOOT/ups/* /etc/nut
+cp -f $BOOT/ups/* /etc/nut >/dev/null 2>&1
 
 # update permissions
 if [ -d /etc/nut ]; then

--- a/source/nut/usr/local/emhttp/plugins/nut/NUTdetails.page
+++ b/source/nut/usr/local/emhttp/plugins/nut/NUTdetails.page
@@ -32,6 +32,8 @@ table.tablesorter tbody tr:nth-child(even) {
 <tbody id="nut_status"><tr><td colspan="4" style="text-align:center"><i class="fa fa-spinner fa-spin icon"></i><em>Please wait, retrieving UPS information...</em></td></tr></tbody>
 </table>
 
+<div style="font-size:x-small;font-weight:bold;"><a href="/plugins/nut/include/nut_status.php?diagsave=true&all=true">Save Diagnostics</a></div>
+
 <script>
 function getNUTstatus() {
   $.get('/plugins/nut/include/nut_status.php',{all:'true'},function(data) {

--- a/source/nut/usr/local/emhttp/plugins/nut/include/nut_status.php
+++ b/source/nut/usr/local/emhttp/plugins/nut/include/nut_status.php
@@ -29,6 +29,18 @@ $result = [];
 
 if (file_exists('/var/run/nut/upsmon.pid')) {
   exec("/usr/bin/upsc ".escapeshellarg($nut_name)."@$nut_ip 2>/dev/null", $rows);
+
+  if ($_GET['diagsave'] == "true") {
+
+  $diagstring = implode("\n",$rows);
+  header('Content-Disposition: attachment; filename="nut-diagnostics.dev"');
+  header('Content-Type: text/plain');
+  header('Content-Length: ' . strlen($diagstring));
+  header('Connection: close');
+  die($diagstring);
+
+  }
+
   for ($i=0; $i<count($rows); $i++) {
     $row = array_map('trim', explode(':', $rows[$i], 2));
     $key = $row[0];

--- a/source/nut/usr/local/emhttp/plugins/nut/include/nut_status.php
+++ b/source/nut/usr/local/emhttp/plugins/nut/include/nut_status.php
@@ -32,7 +32,15 @@ if (file_exists('/var/run/nut/upsmon.pid')) {
 
   if ($_GET['diagsave'] == "true") {
 
-  $diagstring = implode("\n",$rows);
+  $diagarray = $rows;
+  
+  array_walk($diagarray, function(&$var) {
+    if (preg_match('/^(device|ups)\.(serial|macaddr):/i', $var, $matches)) {
+      $var = $matches[1] . '.' . $matches[2] . ': REMOVED';
+    }
+  });
+
+  $diagstring = implode("\n",$diagarray);
   header('Content-Disposition: attachment; filename="nut-diagnostics.dev"');
   header('Content-Type: text/plain');
   header('Content-Length: ' . strlen($diagstring));


### PR DESCRIPTION
- **fix:** reduce console spam of copy operations by redirecting output to /dev/null, as requested in https://github.com/SimonFair/NUT-unRAID/pull/3#issuecomment-1649094177

- **fix:** stop services before a plugin upgrade on the live system to remove any file locks preventing files from getting patched on the running instance. a reboot should now no longer be required for all changes to become active.

- **fix:** old installation remnants cause updating or transitioning to another nut package on running instance to fail

- **fix:** fix a permissions issue causing some drivers in 2.8.0 not to have access to their required folders

- **new:** add button for users to be able to save their UPS details into a dummy-ups compliant diagnostics file
this file can then be uploaded on the forums and given to the developers in case problems with the plugin arise
thanks to @Peuuuur-Noel for the improvements to the privacy of the exported files (removing serial, macaddr)
