### PR TITLE
permission fixes for 2.8.0 transition

### DIFF
--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -360,6 +360,7 @@ rm -rf /var/run/nut
 rm -rf /etc/nut
 rm -rf /etc/ups
 rm -rf /var/run/nut
+rm -rf /var/state/ups
 
 echo ""
 echo "-----------------------------------------------------------"

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -323,6 +323,7 @@ rm -f &plgPATH;/*.txz \
 rm -rf /etc/nut
 rm -rf /etc/ups
 rm -rf /var/run/nut
+rm -rf /var/state/ups
 
 echo ""
 echo "-----------------------------------------------------------"

--- a/source/nut/etc/rc.d/rc.nut
+++ b/source/nut/etc/rc.d/rc.nut
@@ -205,20 +205,22 @@ write_config() {
         mkdir $PLGPATH/ups
     fi
 	
-    cp -f /etc/nut/* $PLGPATH/ups >/dev/null 2>&1
- 
     # update permissions
     if [ -d /etc/nut ]; then
         echo "Updating permissions..."
         chown root:nut /etc/nut/*
-        chmod 640 /etc/nut/*
+        chmod 0770 /etc/nut/*
+        chown root:nut /etc/nut
+        chmod 0770 /etc/nut
+        chown root:nut /etc/ups
+        chmod 0770 /etc/ups
         chown root:nut /var/run/nut
         chmod 0770 /var/run/nut
         chown root:nut /var/state/ups
         chmod 0770 /var/state/ups
-        #chown -R 218:218 /etc/nut
-        #chmod -R 0644 /etc/nut
     fi
+
+    cp -f /etc/nut/* $PLGPATH/ups >/dev/null 2>&1
 
     # Link shutdown scripts for poweroff in rc.6
     if [ $( grep -ic "/etc/rc.d/rc.nut restart_udev" /etc/rc.d/rc.6 ) -eq 0 ]; then

--- a/source/nut/install/doinst.sh
+++ b/source/nut/install/doinst.sh
@@ -12,7 +12,11 @@ if [ $( grep -ic "218" /etc/passwd ) -eq 0 ]; then
 fi
 
 # Update file permissions of scripts
-chmod +0755 $DOCROOT/scripts/* \
+chown root:nut $DOCROOT/scripts/* \
+        /etc/rc.d/rc.nut \
+        /usr/sbin/nut-notify
+
+chmod 0770 $DOCROOT/scripts/* \
         /etc/rc.d/rc.nut \
         /usr/sbin/nut-notify
 
@@ -43,6 +47,8 @@ cp -f $BOOT/ups/* /etc/nut >/dev/null 2>&1
 
 # update permissions
 if [ -d /etc/nut ]; then
-    chown -R 218:218 /etc/nut
-    chmod -R -r /etc/nut
+    chown root:nut /etc/nut/*
+    chmod 0770 /etc/nut/*
+    chown root:nut /etc/nut
+    chmod 0770 /etc/nut
 fi


### PR DESCRIPTION
since we're moving in the direction of 2.8.0 i've checked for permission issues
those are now resolved by streamlining all outdated permissions to the current ones
this ensures that all services, drivers and scripts are using the same permissions 

tested working on 6.12.3 and ready to merge (not urgent)
