### PR TITLE
improve PLG routines and persist user configuration

### DIFF
--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -183,6 +183,17 @@
 - Test Version (plg)
 </CHANGES>
 
+<FILE Run="/bin/bash">
+<INLINE>
+# if upgrading on live system, stop the services first
+# to release any remaining file locks before patching
+echo "Making sure all existing NUT services are stopped..."
+if [ -x /etc/rc.d/rc.nut ]; then
+    /etc/rc.d/rc.nut stop 2>/dev/null
+fi
+</INLINE>
+</FILE>
+
 <!--
 dependency files
 -->
@@ -190,17 +201,17 @@ dependency files
 <!--
 The 'nut-package' file.
 -->
-<FILE Name="&plgPATH;/nut-2.8.0-x86_64-2.txz" Min="6.13" >
+<FILE Name="&plgPATH;/nut-2.8.0-x86_64-2.ssl3.txz" Min="6.13" Run="upgradepkg --install-new">
 <URL>&pkgURL;/nut-2.8.0-x86_64-2.ssl3.txz</URL>
 <MD5>f49b17d960920c6970ad3787a55811f6</MD5>
 </FILE>
 
-<FILE Name="&plgPATH;/nut-2.8.0-x86_64-2.txz" Min="6.10" Max="6.12.99" >
+<FILE Name="&plgPATH;/nut-2.8.0-x86_64-2.ssl11.txz" Min="6.10" Max="6.12.99" Run="upgradepkg --install-new">
 <URL>&pkgURL;/nut-2.8.0-x86_64-2.ssl11.txz</URL>
 <MD5>50c1fde33e3bb0fe398697bf1e212f75</MD5>
 </FILE>
 
-<FILE Name="&plgPATH;/nut-2.7.4.20200318-x86_64-1.txz" Min="6.8" Max ="6.9.99" Run="upgradepkg --install-new">
+<FILE Name="&plgPATH;/nut-2.7.4.20200318-x86_64-1.txz" Min="6.8" Max="6.9.99" Run="upgradepkg --install-new">
 <URL>&pkgURL;/nut-2.7.4.20200318-x86_64-1.txz</URL>
 <MD5>52de2867d6b8f6bc1a98a45870b05420</MD5>
 </FILE>
@@ -279,12 +290,6 @@ if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
     rm -f &plgPATH;/&plgNAME;.md5
     exit 1
 else
-    # if upgrading on live system, stop the services here
-    # to release any remaining file locks before patching
-    if [ -x /etc/rc.d/rc.nut ]; then
-        /etc/rc.d/rc.nut stop 2>/dev/null
-    fi
-
     # nut-2.7.4 and nut plugin expects:
     #   Config: /etc/nut
     #   Pid   : /var/run/nut/upsmon.pid
@@ -303,13 +308,6 @@ else
         mkdir /var/run/nut
         ln -sf /var/run/upsmon.pid /var/run/nut/upsmon.pid
     fi
-
-    # Stop service
-    #echo "stopping services..."
-    #/etc/rc.d/rc.nut stop 2>/dev/null
-
-    # Upgrade Nut package to latest 2.8 
-    upgradepkg --install-new &plgPATH;/nut-2.8.0-x86_64-2.txz
 
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -362,7 +362,6 @@ fi
 
 removepkg &plgPATH;/*.txz
 rm -rf &emhttp;
-rm -rf &plgPATH;/ups
 rm -f &plgPATH;/*.txz \
     &plgPATH;/*.md5
 

--- a/plugin/nut-2.8.0.plg
+++ b/plugin/nut-2.8.0.plg
@@ -185,12 +185,16 @@
 
 <FILE Run="/bin/bash">
 <INLINE>
-# if upgrading on live system, stop the services first
-# to release any remaining file locks before patching
-echo "Making sure all existing NUT services are stopped..."
+echo "Making sure all existing NUT services are stopped (before install/upgrade)..."
 if [ -x /etc/rc.d/rc.nut ]; then
-    /etc/rc.d/rc.nut stop 2>/dev/null
+    if ! /etc/rc.d/rc.nut stop >/dev/null 2>&amp;1; then
+        echo "WARNING:"
+        echo "WARNING: The NUT installation script was not able to stop all services gracefully."
+        echo "WARNING: IN CASE OF PROBLEMS, please REBOOT YOUR SYSTEM to complete any upgrades."
+        echo "WARNING:"
+    fi 
 fi
+exit 0
 </INLINE>
 </FILE>
 
@@ -340,8 +344,15 @@ The 'remove' script.
 -->
 <FILE Run="/bin/bash" Method="remove">
 <INLINE>
-# Stop service
-/etc/rc.d/rc.nut stop 2>/dev/null
+echo "Making sure all existing NUT services are stopped (before uninstall)..."
+if [ -x /etc/rc.d/rc.nut ]; then
+    if ! /etc/rc.d/rc.nut stop >/dev/null 2>&amp;1; then
+        echo "WARNING:"
+        echo "WARNING: The NUT uninstallation script was not able to stop all services gracefully."
+        echo "WARNING: IN CASE OF PROBLEMS, please REBOOT YOUR SYSTEM to remove any remaining packages."
+        echo "WARNING:"
+    fi 
+fi
 
 # check if net-snmp is used by another plugin
 if [ `find /boot/config/plugins/*.plg -type f ! -iname "*&name;.plg*" | xargs grep "net-snmp" -sl` ]; then

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -183,6 +183,17 @@
 - Test Version (plg)
 </CHANGES>
 
+<FILE Run="/bin/bash">
+<INLINE>
+# if upgrading on live system, stop the services first
+# to release any remaining file locks before patching
+echo "Making sure all existing NUT services are stopped..."
+if [ -x /etc/rc.d/rc.nut ]; then
+    /etc/rc.d/rc.nut stop 2>/dev/null
+fi
+</INLINE>
+</FILE>
+
 <!--
 dependency files
 -->
@@ -190,17 +201,17 @@ dependency files
 <!--
 The 'nut-package' file.
 -->
-<FILE Name="&plgPATH;/nut-2.8.0-x86_64-2.txz" Min="6.13" >
+<FILE Name="&plgPATH;/nut-2.8.0-x86_64-2.ssl3.txz" Min="6.13" Run="upgradepkg --install-new">
 <URL>&pkgURL;/nut-2.8.0-x86_64-2.ssl3.txz</URL>
 <MD5>f49b17d960920c6970ad3787a55811f6</MD5>
 </FILE>
 
-<FILE Name="&plgPATH;/nut-2.8.0-x86_64-2.txz" Min="6.10" Max="6.12.99" >
+<FILE Name="&plgPATH;/nut-2.8.0-x86_64-2.ssl11.txz" Min="6.10" Max="6.12.99" Run="upgradepkg --install-new">
 <URL>&pkgURL;/nut-2.8.0-x86_64-2.ssl11.txz</URL>
 <MD5>50c1fde33e3bb0fe398697bf1e212f75</MD5>
 </FILE>
 
-<FILE Name="&plgPATH;/nut-2.7.4.20200318-x86_64-1.txz" Min="6.8" Max ="6.9.99" Run="upgradepkg --install-new">
+<FILE Name="&plgPATH;/nut-2.7.4.20200318-x86_64-1.txz" Min="6.8" Max="6.9.99" Run="upgradepkg --install-new">
 <URL>&pkgURL;/nut-2.7.4.20200318-x86_64-1.txz</URL>
 <MD5>52de2867d6b8f6bc1a98a45870b05420</MD5>
 </FILE>
@@ -277,12 +288,6 @@ if [ "${sum1:0:32}" != "${sum2:0:32}" ]; then
     rm -f &plgPATH;/&plgNAME;.md5
     exit 1
 else
-    # if upgrading on live system, stop the services here
-    # to release any remaining file locks before patching
-    if [ -x /etc/rc.d/rc.nut ]; then
-        /etc/rc.d/rc.nut stop 2>/dev/null
-    fi
-
     # nut-2.7.4 and nut plugin expects:
     #   Config: /etc/nut
     #   Pid   : /var/run/nut/upsmon.pid
@@ -301,13 +306,6 @@ else
         mkdir /var/run/nut
         ln -sf /var/run/upsmon.pid /var/run/nut/upsmon.pid
     fi
-
-    # Stop service
-    #echo "stopping services..."
-    #/etc/rc.d/rc.nut stop 2>/dev/null
-
-    # Upgrade Nut package to latest 2.8 
-    upgradepkg --install-new &plgPATH;/nut-2.8.0-x86_64-2.txz
 
     # upgrade plugin package
     upgradepkg --install-new &plgPATH;/&plgNAME;.txz

--- a/plugin/nut.plg
+++ b/plugin/nut.plg
@@ -185,12 +185,16 @@
 
 <FILE Run="/bin/bash">
 <INLINE>
-# if upgrading on live system, stop the services first
-# to release any remaining file locks before patching
-echo "Making sure all existing NUT services are stopped..."
+echo "Making sure all existing NUT services are stopped (before install/upgrade)..."
 if [ -x /etc/rc.d/rc.nut ]; then
-    /etc/rc.d/rc.nut stop 2>/dev/null
+    if ! /etc/rc.d/rc.nut stop >/dev/null 2>&amp;1; then
+        echo "WARNING:"
+        echo "WARNING: The NUT installation script was not able to stop all services gracefully."
+        echo "WARNING: IN CASE OF PROBLEMS, please REBOOT YOUR SYSTEM to complete any upgrades."
+        echo "WARNING:"
+    fi 
 fi
+exit 0
 </INLINE>
 </FILE>
 
@@ -338,8 +342,15 @@ The 'remove' script.
 -->
 <FILE Run="/bin/bash" Method="remove">
 <INLINE>
-# Stop service
-/etc/rc.d/rc.nut stop 2>/dev/null
+echo "Making sure all existing NUT services are stopped (before uninstall)..."
+if [ -x /etc/rc.d/rc.nut ]; then
+    if ! /etc/rc.d/rc.nut stop >/dev/null 2>&amp;1; then
+        echo "WARNING:"
+        echo "WARNING: The NUT uninstallation script was not able to stop all services gracefully."
+        echo "WARNING: IN CASE OF PROBLEMS, please REBOOT YOUR SYSTEM to remove any remaining packages."
+        echo "WARNING:"
+    fi 
+fi
 
 # check if net-snmp is used by another plugin
 if [ `find /boot/config/plugins/*.plg -type f ! -iname "*&name;.plg*" | xargs grep "net-snmp" -sl` ]; then
@@ -349,7 +360,6 @@ fi
 
 removepkg &plgPATH;/*.txz
 rm -rf &emhttp;
-rm -rf &plgPATH;/ups
 rm -f &plgPATH;/*.txz \
     &plgPATH;/*.md5
 


### PR DESCRIPTION
I'd advise against the current way of upgrading, because it expects for a hard coded file "nut-2.8.0-x86_64-2.txz" to be present, which will not be present on older UNRAID systems where packages such as 2.7.4. will get pulled in. Also, renaming both versions ssl11 and ssl3 to a common name can lead to later trouble figuring out which package a user actually has installed.

While this PR returns to the previous way of upgrading, it places a script to stop all NUT services at the very top of the installation routine, so that all services will always be stopped and file locks released before anything else happens.

This PR also prepares to keep user configurations between re-installs, but I'd strongly advise to also merge #18 because it introduces a function where users can hard-reset their NUT configuration in case they messed it up somehow. Because if we let users keep their configurations and never overwrite with defaults, we should at least offer a way to revert a broken configuration to "normal" without having to uninstall and reinstall the plugin.